### PR TITLE
Improve robustness of loot and gold tracking helpers

### DIFF
--- a/Gathering/Elements/Gold.lua
+++ b/Gathering/Elements/Gold.lua
@@ -8,50 +8,50 @@ local floor = math.floor
 local max = math.max
 
 function Gathering:PLAYER_MONEY()
-	if (self.Settings.IgnoreMailMoney and InboxFrame:IsVisible()) then
-		return
-	end
-
-	if (GuildBankFrame and GuildBankFrame:IsVisible()) then
-		return
-	end
-
-    local Current = GetMoney()
-
-    if (self.GoldValue == Current) then
-        return
-    end
-
-    local DisplayMode = self.Settings.DisplayMode
-    local Now = GetTime()
-    local Diff = Current - self.GoldValue
-
-    self.GoldGained = Current - self.StartingGold
-
-    if (self.GoldTimer == 0) then
-        self.GoldTimer = Now
-    end
-
-    if (DisplayMode == "TIME") then
-        self:StartTimer()
-    elseif (DisplayMode == "GPH") then
-        if (self.GoldGained ~= 0) then
-            self.Text:SetFormattedText(L["GPH: %s"], self:CopperToGold(floor((self.GoldGained / max(Now - self.GoldTimer, 1)) * 60 * 60)))
+        if (self.Settings.IgnoreMailMoney and InboxFrame and InboxFrame:IsVisible()) then
+                return
         end
 
-        if (not self:GetScript("OnUpdate")) then
-            self:SetScript("OnUpdate", self.OnUpdate)
+        if (GuildBankFrame and GuildBankFrame:IsVisible()) then
+                return
         end
-    elseif (DisplayMode == "GOLD") then
-        self.Text:SetText(self:CopperToGold(self.GoldGained))
-    end
 
-	if (Diff > 0) then
-		self:AddStat("gold", Diff)
-		self:UpdateMoneyStat()
-	end
+        local Current = GetMoney()
 
-    self.GoldValue = Current
+        if (self.GoldValue == Current) then
+                return
+        end
+
+        local DisplayMode = self.Settings.DisplayMode
+        local Now = GetTime()
+        local Diff = Current - self.GoldValue
+
+        self.GoldGained = Current - self.StartingGold
+
+        if (self.GoldTimer == 0) then
+                self.GoldTimer = Now
+        end
+
+        if (DisplayMode == "TIME") then
+                self:StartTimer()
+        elseif (DisplayMode == "GPH") then
+                if (self.GoldGained ~= 0) then
+                        self.Text:SetFormattedText(L["GPH: %s"], self:CopperToGold(floor((self.GoldGained / max(Now - self.GoldTimer, 1)) * 60 * 60)))
+                end
+
+                if (not self:GetScript("OnUpdate")) then
+                        self:SetScript("OnUpdate", self.OnUpdate)
+                end
+        elseif (DisplayMode == "GOLD") then
+                self.Text:SetText(self:CopperToGold(self.GoldGained))
+        end
+
+        if (Diff > 0) then
+                self:AddStat("gold", Diff)
+                self:UpdateMoneyStat()
+        end
+
+        self.GoldValue = Current
 end
 
 Gathering:RegisterEvent("PLAYER_MONEY")

--- a/Gathering/Elements/Loot.lua
+++ b/Gathering/Elements/Loot.lua
@@ -16,60 +16,74 @@ local ValidMessages = {
 }
 
 function Gathering:CHAT_MSG_LOOT(msg)
-    if not msg then return end
+        if (not msg) then
+                return
+        end
 
-    if (self.Settings.IgnoreMailItems and InboxFrame:IsVisible()) or (GuildBankFrame and GuildBankFrame:IsVisible()) then
-        return
-    end
+        if ((self.Settings.IgnoreMailItems and InboxFrame and InboxFrame:IsVisible()) or (GuildBankFrame and GuildBankFrame:IsVisible())) then
+                return
+        end
 
-    local PreMessage, ItemString, Name, Quantity = msg:match(LootMatch)
+        local PreMessage, ItemString, Name, Quantity = msg:match(LootMatch)
 
-    if not ItemString or not Name then return end
+        if (not ItemString or not Name) then
+                return
+        end
 
-    if PreMessage and not ValidMessages[PreMessage] then
-        return
-    end
+        if (PreMessage and not ValidMessages[PreMessage]) then
+                return
+        end
 
-    Quantity = tonumber(Quantity) or 1
+        Quantity = tonumber(Quantity) or 1
 
-    local LinkType, ID = ItemString:match("^(%a+):(%d+)")
-    ID = tonumber(ID)
-    if not ID then return end
+        local LinkType, ID = ItemString:match("^(%a+):(%d+)")
+        ID = tonumber(ID)
 
-    local _, _, Quality, _, _, Type, SubType, _, _, Texture, _, ClassID, SubClassID, BindType = GetItemInfo(ID)
-    if self.Ignored[ID] or self.Ignored[Name] or not self.TrackedItemTypes[ClassID] or not self.TrackedItemTypes[ClassID][SubClassID] then
-        return
-    end
+        if (not ID) then
+                return
+        end
 
-    if BindType and BindType ~= 0 and self.Settings["ignore-bop"] then
-        return
-    end
+        local _, _, Quality, _, _, Type, SubType, _, _, Texture, _, ClassID, SubClassID, BindType = GetItemInfo(ID)
 
-    local Now = GetTime()
-    if not self.Gathered[SubType] then self.Gathered[SubType] = {} end
-    if not self.Gathered[SubType][ID] then self.Gathered[SubType][ID] = {Initial = Now} end
+        if (self.Ignored[ID] or self.Ignored[Name] or not self.TrackedItemTypes[ClassID] or not self.TrackedItemTypes[ClassID][SubClassID]) then
+                return
+        end
 
-    local Info = self.Gathered[SubType][ID]
-    Info.Collected = (Info.Collected or 0) + Quantity
-    Info.Last = Now
+        if (BindType and BindType ~= 0 and self.Settings["ignore-bop"]) then
+                return
+        end
 
-    self.TotalGathered = self.TotalGathered + Quantity
+        local Now = GetTime()
 
-    if self.Settings.DisplayMode == "TOTAL" then
-        self.Text:SetFormattedText(L["Total: %s"], self.TotalGathered)
-    end
+        if (not self.Gathered[SubType]) then
+                self.Gathered[SubType] = {}
+        end
 
-    if not self:GetScript("OnUpdate") then
-        self:StartTimer()
-    end
+        if (not self.Gathered[SubType][ID]) then
+                self.Gathered[SubType][ID] = { Initial = Now }
+        end
 
-    self:AddStat("total", Quantity)
-    self:UpdateItemsStat()
+        local Info = self.Gathered[SubType][ID]
+        Info.Collected = (Info.Collected or 0) + Quantity
+        Info.Last = Now
 
-    if self.MouseIsOver then
-        self:OnLeave()
-        self:OnEnter()
-    end
+        self.TotalGathered = self.TotalGathered + Quantity
+
+        if (self.Settings.DisplayMode == "TOTAL") then
+                self.Text:SetFormattedText(L["Total: %s"], self.TotalGathered)
+        end
+
+        if (not self:GetScript("OnUpdate")) then
+                self:StartTimer()
+        end
+
+        self:AddStat("total", Quantity)
+        self:UpdateItemsStat()
+
+        if (self.MouseIsOver) then
+                self:OnLeave()
+                self:OnEnter()
+        end
 end
 
 Gathering:RegisterEvent("CHAT_MSG_LOOT")

--- a/Gathering/Elements/Stats.lua
+++ b/Gathering/Elements/Stats.lua
@@ -5,20 +5,14 @@ local Gathering = AddOn.Gathering
 local SessionStat = {}
 
 function Gathering:AddStat(stat, value)
-	if (not GatheringStats) then
-		GatheringStats = {}
-	end
+        if (not GatheringStats) then
+                GatheringStats = {}
+        end
 
-	if (not GatheringStats[stat]) then
-		GatheringStats[stat] = 0
-	end
+        local Amount = value or 1
 
-	if (not SessionStat[stat]) then
-		SessionStat[stat] = 0
-	end
-
-	GatheringStats[stat] = GatheringStats[stat] + (value or 1)
-	SessionStat[stat] = SessionStat[stat] + (value or 1)
+        GatheringStats[stat] = (GatheringStats[stat] or 0) + Amount
+        SessionStat[stat] = (SessionStat[stat] or 0) + Amount
 end
 
 Gathering.SessionStats = SessionStat

--- a/Gathering/Elements/Tools.lua
+++ b/Gathering/Elements/Tools.lua
@@ -108,28 +108,31 @@ function Gathering:GetPrice(link, id)
 end
 
 function Gathering:GetTrashValue()
-	local Profit = 0
+        local Profit = 0
 
-	for Bag = 0, 4 do
-		for Slot = 1, GetContainerNumSlots(Bag) do
-			local Link = GetContainerItemLink(Bag, Slot)
+        for Bag = 0, 4 do
+                local Slots = GetContainerNumSlots(Bag) or 0
 
-			if Link then
-				local Quality = select(3, GetItemInfo(Link)) -- Just list out the arguments as dummies and save the 2 select calls
-				local VendorPrice = select(11, GetItemInfo(Link))
-				local Count = GetContainerItemInfo(Bag, Slot).stackCount or 1
-				local TotalPrice = VendorPrice
+                for Slot = 1, Slots do
+                        local Link = GetContainerItemLink(Bag, Slot)
 
-				if ((VendorPrice and (VendorPrice > 0)) and Count) then
-					TotalPrice = VendorPrice * Count
-				end
+                        if Link then
+                                local _, _, Quality, _, _, _, _, _, _, _, VendorPrice = GetItemInfo(Link)
+                                local ItemInfo, Count = GetContainerItemInfo(Bag, Slot)
+                                local StackCount = 1
 
-				if ((Quality and Quality < 1) and TotalPrice > 0) then
-					Profit = Profit + TotalPrice
-				end
-			end
-		end
-	end
+                                if (type(ItemInfo) == "table") then
+                                        StackCount = ItemInfo.stackCount or ItemInfo.count or 1
+                                else
+                                        StackCount = Count or 1
+                                end
 
-	return Profit
+                                if ((Quality and Quality < 1) and VendorPrice and VendorPrice > 0) then
+                                        Profit = Profit + (VendorPrice * StackCount)
+                                end
+                        end
+                end
+        end
+
+        return Profit
 end


### PR DESCRIPTION
## Summary
- avoid calling InboxFrame methods when the frame has not been loaded before checking mail-related settings
- streamline stat accumulation and trash value calculations while supporting legacy container APIs
- keep tooltips and timers accurate by ensuring guard clauses use consistent structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ba9e6558832fb53369ef18a937aa